### PR TITLE
Fix links to paper PDFs files in README

### DIFF
--- a/README
+++ b/README
@@ -25,13 +25,13 @@ Further Information:
 * Website: https://www.nntb.no.
 
 * Gran, Ernst Gunnar; Dreibholz, Thomas and Kvalbein, Amund: «NorNet Core – A Multi-Homed Research Testbed» (PDF, 1458 KiB, in English), in Computer Networks, Special Issue on Future Internet Testbeds, DOI 10.1016/j.bjp.2013.12.035, ISSN 1389-1286, January 3, 2014.
-URL: https://simula.no/publications/Simula.simula.2236/simula_pdf_file
+URL: https://www.simula.no/file/simulasimula2236pdf/download
 BibTeX: https://www.nntb.no/pub/nornet-publications/bibtex/ComNets2013-Core.bib
 
 * Dreibholz, Thomas and Gran, Ernst Gunnar: «Design and Implementation of the NorNet Core Research Testbed for Multi-Homed Systems» (PDF, 20082 KiB, in English), in Proceedings of the 3nd International Workshop on Protocols and Applications with Multi-Homing Support (PAMS), pp. 1094–1100, DOI 10.1109/WAINA.2013.71, ISBN 978-0-7695-4952-1, Barcelona, Catalonia/Spain, March 27, 2013.
-URL: https://simula.no/publications/threfereedinproceedingsreference.2012-12-20.7643198512/simula_pdf_file
+URL: https://www.simula.no/file/threfereedinproceedingsreference2012-12-207643198512pdf/download
 BibTeX: https://www.nntb.no/pub/nornet-publications/bibtex/PAMS2013-NorNet.bib
 
 * Kvalbein, Amund; Baltrūnas, Džiugas; Evensen, Kristian Riktor; Xiang, Jie; Elmokashfi, Ahmed and Ferlin-Oliveira, Simone: «The NorNet Edge Platform for Mobile Broadband Measurements» (PDF, 2742 KiB, in English), in Computer Networks, Special Issue on Future Internet Testbeds, DOI 10.1016/j.bjp.2013.12.036, ISSN 1389-1286, January 3, 2014.
-URL: https://simula.no/publications/Simula.simula.2434/simula_pdf_file
+URL: https://simula.no/file/simulasimula2434pdf/download
 BibTeX: https://www.nntb.no/pub/nornet-publications/bibtex/ComNets2013-Edge.bib


### PR DESCRIPTION
This commit fixes the URLs of the PDF files of papers listed in the repo's README. There are BibTeX files available from simula.no as well, although they seem to be less complete than nntb.no's versions.

Anyway, I'll list them below for completeness' sake:
- https://www.simula.no/biblio/export/bibtex/21556
- https://www.simula.no/biblio/export/bibtex/20535
- https://www.simula.no/biblio/export/bibtex/21093
